### PR TITLE
Limit the number of pytorch threads

### DIFF
--- a/allentune/modules/allennlp_runner.py
+++ b/allentune/modules/allennlp_runner.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from typing import Optional
 
 import pandas as pd
+import torch
 from allennlp.commands.train import train_model
 from allennlp.common.params import Params, parse_overrides, with_fallback
 from allennlp.common.util import import_submodules
@@ -49,6 +50,9 @@ class AllenNlpRunner(object):
             if args.num_gpus == 0:
                 logger.warning(f"No GPU specified, using CPU.")
                 params_dict["trainer"]["cuda_device"] = -1
+
+            if args.cpus_per_trial > 0:
+                torch.set_num_threads(args.cpus_per_trial)
 
             params = Params(params_dict)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ ray==0.6.2
 git+git://github.com/allenai/allennlp@27ebcf6ba3e02afe341a5e62cb1a7d5c6906c0c9
 seaborn
 pandas
+torch
 
 # Testing
 pytest


### PR DESCRIPTION
Running multiple experiments with extensive cpu usage can lead to a clogged machine, where the single runs are slowing down each other due to extensive rescheduling. This can be resolved by limiting the available pytorch threads.